### PR TITLE
added new endpoint: /get-events/:game-id to retreive events for a specific game

### DIFF
--- a/src/clj_highscore/core.clj
+++ b/src/clj_highscore/core.clj
@@ -140,6 +140,21 @@
              :available-media-types ["application/json"]
              )
 
+(defresource get-events
+             [game-id]
+             :allowed-methods [:get]
+             :available-media-types ["application/json"]
+             :malformed? (fn [context]
+                           (or (nil? game-id)
+                               (db/has-game score-dbspec game-id)))
+
+             :handle-malformed "The game by the specified game id cannot be found."
+
+             :handle-ok
+             (fn [context]
+               (db/get-game-and-events score-dbspec game-id)
+               )
+             )
 
 
 
@@ -147,6 +162,8 @@
 (defroutes app
            (ANY "/" resource)
            (GET "/get-scores/:game" [game] (get-scores game))
+           (GET "/get-events/:game-id" [game-id] (get-events (Integer. game-id)))
+
            (POST "/new-score" [] add-score)
            (POST "/new-game/:game" [game] (new-game game))
 


### PR DESCRIPTION
Example usage:

GET -- http://localhost:3000/get-events/11

-- 200 OK
{
  "user_name": "T",
  "score": 8,
  "duration": 16599,
  "game_name": "clj-snake",
  "events": [
    {
      "id": 101,
      "ts": 5245,
      "event_name": "keystroke"
    },
    {
      "id": 102,
      "ts": 5741,
      "event_name": "keystroke"
    },
    {
      "id": 103,
      "ts": 6047,
      "event_name": "keystroke"
    },
    {
      "id": 104,
      "ts": 7113,
      "event_name": "keystroke"
    },
    {
      "id": 105,
      "ts": 9989,
      "event_name": "keystroke"
    },
    {
      "id": 106,
      "ts": 10365,
      "event_name": "keystroke"
    },
    {
      "id": 107,
      "ts": 10529,
      "event_name": "keystroke"
    },
    {
      "id": 108,
      "ts": 10814,
      "event_name": "keystroke"
    },
    {
      "id": 109,
      "ts": 7829,
      "event_name": "pill"
    },
    {
      "id": 110,
      "ts": 10066,
      "event_name": "pill"
    }
  ]
}
